### PR TITLE
refer to mirage module types modules by new name

### DIFF
--- a/src/mirage/dhcp_client_mirage.ml
+++ b/src/mirage/dhcp_client_mirage.ml
@@ -1,4 +1,4 @@
-let ipv4_config_of_lease lease : V1_LWT.ipv4_config option =
+let ipv4_config_of_lease lease : Mirage_types_lwt.ipv4_config option =
   let open Dhcp_wire in
   (* ipv4_config expects a single IP address and the information
    * needed to construct a prefix.  It can optionally use one router. *)
@@ -9,16 +9,16 @@ let ipv4_config_of_lease lease : V1_LWT.ipv4_config option =
     let network = Ipaddr.V4.Prefix.of_netmask subnet address in
     let valid_routers = Dhcp_wire.collect_routers lease.options in
     match valid_routers with
-    | [] -> Some (V1_LWT.{ address; network; gateway = None })
-    | hd::_ -> Some (V1_LWT.{ address; network; gateway = (Some hd) })
+    | [] -> Some (Mirage_types_lwt.{ address; network; gateway = None })
+    | hd::_ -> Some (Mirage_types_lwt.{ address; network; gateway = (Some hd) })
 
 let src = Logs.Src.create "dhcp_client"
 module Log = (val Logs.src_log src : Logs.LOG)
 
-module Make(Time : V1_LWT.TIME) (Net : V1_LWT.NETWORK) = struct
+module Make(Time : Mirage_types_lwt.TIME) (Net : Mirage_types_lwt.NETWORK) = struct
   open Lwt.Infix
 
-  type t = V1_LWT.ipv4_config Lwt_stream.t
+  type t = Mirage_types_lwt.ipv4_config Lwt_stream.t
 
   let usable_config_of_lease = function
   | None -> None

--- a/src/mirage/dhcp_client_mirage.mli
+++ b/src/mirage/dhcp_client_mirage.mli
@@ -1,4 +1,4 @@
-val ipv4_config_of_lease : Dhcp_wire.pkt -> V1_LWT.ipv4_config option
+val ipv4_config_of_lease : Dhcp_wire.pkt -> Mirage_types_lwt.ipv4_config option
 (** [ipv4_config_of_lease pkt] checks whether [pkt] represents
  *  a valid IPv4 configuration (regardless of the time at which
  *  [pkt] was sent and the time given for its validity).  If [pkt]
@@ -7,8 +7,8 @@ val ipv4_config_of_lease : Dhcp_wire.pkt -> V1_LWT.ipv4_config option
  *  lease containing the minimum information needed for an
  *  IPv4 configuration, [ipv4_config_of_lease pkt] returns [None]. *)
 
-module Make(Time : V1_LWT.TIME) (Network : V1_LWT.NETWORK) : sig
-  type t = V1_LWT.ipv4_config Lwt_stream.t
+module Make(Time : Mirage_types_lwt.TIME) (Network : Mirage_types_lwt.NETWORK) : sig
+  type t = Mirage_types_lwt.ipv4_config Lwt_stream.t
   val connect : ?requests:Dhcp_wire.option_code list
     -> Network.t -> t Lwt.t
   (** [connect ?requests net] attempts to use [net] to obtain a valid

--- a/src/mirage/dhcp_ipv4.mli
+++ b/src/mirage/dhcp_ipv4.mli
@@ -14,8 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make (D: V1_LWT.DHCP_CLIENT) (E:V1_LWT.ETHIF) (A: V1_LWT.ARP) : sig
-  include V1_LWT.IPV4 with type ethif = E.t
+module Make (D: Mirage_types_lwt.DHCP_CLIENT) (E:Mirage_types_lwt.ETHIF) (A: Mirage_types_lwt.ARP) : sig
+  include Mirage_types_lwt.IPV4 with type ethif = E.t
   val connect : D.t -> ethif -> A.t -> t Lwt.t
     (** Connect to an ipv4 device using information from a DHCP lease. *)
 end


### PR DESCRIPTION
V1 is now Mirage_types, and V1_LWT is now Mirage_types_lwt, as of MirageOS version 3.0.0.