### PR TITLE
only conditionally compile the mirage sublibrary

### DIFF
--- a/opam
+++ b/opam
@@ -9,7 +9,7 @@ tags:         [ "org:mirage"]
 doc:          "https://docs.mirage.io"
 
 build: ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%"
-  "--tests" "false"
+  "--tests" "false" "--with-mirage" "%{mirage-types-lwt:installed}%"
 ]
 build-test: [
   [ "ocaml" "pkg/pkg.ml" "build" "--tests" "true" ]

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -3,7 +3,7 @@
 #require "topkg"
 open Topkg
 
-let mirage = Conf.with_pkg "mirage-types-lwt"
+let mirage = Conf.with_pkg ~default:false "mirage"
 
 let () =
   Pkg.describe "charrua-client" @@ fun c ->


### PR DESCRIPTION
earlier, mirage was always built `Conf.with_pkg` defaults to true, and nothing was passed via `build`