### PR TITLE
Revert "Ensure that Dhcp_client.input does not raise an exception"

### DIFF
--- a/src/dhcp_client.ml
+++ b/src/dhcp_client.ml
@@ -79,15 +79,9 @@ let respond_if t ~msgtype pkt f =
   | Some m when m = msgtype -> f ()
   | Some _ -> (t, None)
 
-(* this function should be replaced by a direct call to pkt_of_buf once
- * that function is refactored not to throw exceptions on parse failures *)
-let safe_pkt_of_buf buf len =
-  try Dhcp_wire.pkt_of_buf buf len
-  with exn -> Error (Printexc.to_string exn)
-
 let input t buf =
   let open Dhcp_wire in
-  match safe_pkt_of_buf buf (Cstruct.len buf) with
+  match pkt_of_buf buf (Cstruct.len buf) with
   | Error _ -> (t, None)
   | Ok incoming ->
     match t with


### PR DESCRIPTION
This reverts commit 43ea969df30102485c0e847f50cd8c115337f9e2 (from @avsm)

now that charrua-core has a fix for this (see https://github.com/mirage/charrua-core/commit/5a25d8f9362872d0f49ad3d66300c24fd8a45451 -- thx to @haesbaert)