### PR TITLE
add conflict on older mirage-types-lwt

### DIFF
--- a/opam
+++ b/opam
@@ -34,4 +34,8 @@ depends: [
 depopts: [
   "mirage-types-lwt"
 ]
+conflicts: [
+  "mirage-types-lwt" {<"3.0.0"}
+  "mirage-types" {<"3.0.0"}
+]
 available: [ocaml-version >= "4.03"]


### PR DESCRIPTION
we should never try to compile with mirage-2 types as it will fail

e.g. see https://ci.ocaml.io/log/saved/docker-run-0dc9451e71d38a75776bbb82d103a43b/e26616d84a773cf7b565c6bc050568bbe5b86f45

